### PR TITLE
Use Docker for building and development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 deploy:
   on:
-    condition: "$TOXENV == py35"
+    condition: "$TOXENV == py36"
     repo: waynr/pyresume
     tags: true
   distributions: sdist bdist_wheel
@@ -9,11 +9,11 @@ deploy:
   provider: pypi
   user: waynr
 env:
-- TOXENV=py35
+- TOXENV=py36
 - TOXENV=flake8
 install: pip install -U tox
 language: python
-python: 3.5
+python: 3.6
 script: tox -e ${TOXENV}
 sudo: required
 services:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -71,14 +71,13 @@ Ready to contribute? Here's how to set up `pyresume` for local development.
 .. code-block:: console
 
     $ git clone git@github.com:your_name_here/pyresume.git
+    $ cd ./pyresume
 
-3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development:
+3. Install your local copy using Docker:
 
 .. code-block:: console
 
-    $ mkvirtualenv pyresume
-    $ cd pyresume/
-    $ python setup.py develop
+    $ docker build --build-arg setup=develop --tag 'wayfair/pyresume:latest' .
 
 4. Create a branch for local development:
 
@@ -88,7 +87,14 @@ Ready to contribute? Here's how to set up `pyresume` for local development.
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox:
+5. Test that PyResume does what you expect:
+
+.. code-block:: console
+
+    # `attributes.yaml` should exist in the `/path/to/yaml/files` directory.
+    $ docker run --volume $PWD:/src/pyresume --volume /path/to/yaml/files:/mnt/pyresume wayfair/pyresume:latest pyresume create tex attributes.yaml > attributes.tex
+
+6. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox:
 
 .. code-block:: console
 
@@ -98,7 +104,7 @@ Ready to contribute? Here's how to set up `pyresume` for local development.
 
    To get flake8 and tox, just pip install them into your virtualenv.
 
-6. Commit your changes and push your branch to GitHub:
+7. Commit your changes and push your branch to GitHub:
 
 .. code-block:: console
 
@@ -106,7 +112,7 @@ Ready to contribute? Here's how to set up `pyresume` for local development.
     $ git commit -m "Your detailed description of your changes."
     $ git push origin name-of-your-bugfix-or-feature
 
-7. Submit a pull request through the GitHub website.
+8. Submit a pull request through the GitHub website.
 
 Pull Request Guidelines
 -----------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -123,7 +123,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.5. Check
+3. The pull request should work for Python 3.6. Check
    https://travis-ci.org/waynr/pyresume/pull_requests and make sure that the
    tests pass for all supported Python versions.
 
@@ -158,7 +158,7 @@ Alternatively, you could just run the entire test suite
 
 .. code-block:: console
 
-   $ tox -e py35
+   $ tox -e py36
 
 Assuming there new resume templates are eventually added, creating the fixture
 might look something like:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:9
+MAINTAINER wayne warren <wayne.warren.s@gmail.com>
+
+VOLUME \
+  # Location of pyresume source.
+  /src/pyresume \
+  # Location of .yaml files for processing.
+  /mnt/pyresume
+
+WORKDIR /mnt/pyresume
+COPY $PWD /src/pyresume
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+RUN \
+  # Install dependencies.
+  apt-get update &&\
+  apt-get -fy install ca-certificates python3 python3-setuptools &&\
+  # Install pyresume.
+  cd /src/pyresume &&\
+  python3 setup.py develop &&\
+  # Clean up all temporary files.
+  apt-get clean &&\
+  apt-get autoclean -y &&\
+  apt-get autoremove -y &&\
+  apt-get clean &&\
+  rm -rf /tmp/* /var/tmp/* &&\
+  rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9
+FROM python:3.6-stretch
 MAINTAINER wayne warren <wayne.warren.s@gmail.com>
 
 # The type of build to invoke from setup.py.
@@ -19,7 +19,7 @@ ENV LC_ALL C.UTF-8
 RUN \
   # Install dependencies.
   apt-get update &&\
-  apt-get -fy install ca-certificates python3 python3-setuptools &&\
+  apt-get -fy install ca-certificates libyaml-0-2 python3 python3-setuptools &&\
   # Install pyresume.
   cd /src/pyresume &&\
   python3 setup.py $setup &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM debian:9
 MAINTAINER wayne warren <wayne.warren.s@gmail.com>
 
+# The type of build to invoke from setup.py.
+ARG setup="install"
+
 VOLUME \
   # Location of pyresume source.
   /src/pyresume \
@@ -19,7 +22,7 @@ RUN \
   apt-get -fy install ca-certificates python3 python3-setuptools &&\
   # Install pyresume.
   cd /src/pyresume &&\
-  python3 setup.py develop &&\
+  python3 setup.py $setup &&\
   # Clean up all temporary files.
   apt-get clean &&\
   apt-get autoclean -y &&\

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,8 +10,8 @@ Installation
 Requirements
 ------------
 
-Python >= 3.5
-  The only tested version of python so far. 
+Python >= 3.6
+  The only tested version of python so far.
 
 For Generating PDFs
 +++++++++++++++++++

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -68,12 +68,17 @@ Or download the `tarball`_:
 
     $ curl  -OL https://github.com/waynr/pyresume/tarball/master
 
-Once you have a copy of the source, you can install it with:
+Once you have a copy of the source, you can run a Docker image:
+
+.. code-block:: console
+
+    $ docker build --tag 'waynr/pyresume:latest' .
+
+You can also install it directly with:
 
 .. code-block:: console
 
     $ python setup.py install
-
 
 .. _Github repo: https://github.com/waynr/pyresume
 .. _tarball: https://github.com/waynr/pyresume/tarball/master

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -68,11 +68,13 @@ Or download the `tarball`_:
 
     $ curl  -OL https://github.com/waynr/pyresume/tarball/master
 
-Once you have a copy of the source, you can run a Docker image:
+Once you have a copy of the source, you can run a Docker image, which should
+bind mount PyResume source and a directory with YAML to convert:
 
 .. code-block:: console
 
     $ docker build --tag 'waynr/pyresume:latest' .
+    $ docker run --tty --interactive --volume /path/to/pyresume:/src/pyresume --volume /path/to/yaml/files:/mnt/pyresume waynr/pyresume:latest /bin/bash
 
 You can also install it directly with:
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     test_suite='tests',
     tests_require=test_requirements

--- a/tests/scenarios/test_scenarios.py
+++ b/tests/scenarios/test_scenarios.py
@@ -116,4 +116,5 @@ class TestTemplateWithScenarios(object):
                 print(line)
             raise
         print(output)
-        assert "Latexmk: All targets (/doc/expected.pdf) are up-to-date" in output
+        assert "Latexmk: All targets (/doc/expected.pdf) are up-to-date" \
+            in output

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -15,8 +15,8 @@ from jinja2 import Environment
 
 def test_standard_template_exists():
     """
-    Validate that the standard LaTeX template is available through pkg_resources
-    at the expected location.
+    Validate that the standard LaTeX template is available through
+    pkg_resources at the expected location.
     """
     assert pkg_resources.resource_exists('pyresume',
                                          'templates/standard.tex')
@@ -24,10 +24,10 @@ def test_standard_template_exists():
 
 def test_standard_template_is_valid_jinja2_format():
     """
-    Validate that the standard LaTeX template is well-formed as far as Jinja2 is
-    concerned.
+    Validate that the standard LaTeX template is well-formed as far as Jinja2
+    is concerned.
     """
     env = Environment()
-    template_string = pkg_resources.resource_string('pyresume',
-                                                    'templates/standard.tex').decode()
+    template_string = pkg_resources.resource_string(
+        'pyresume', 'templates/standard.tex').decode()
     env.parse(template_string)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, flake8
+envlist = py36, flake8
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
This PR suggests the use of Docker for local development and as an option for source installation.

Also cleans up some flake8.

If you like this direction:
- We could probably automate expected testing into Docker.
- We could probably combine the other Docker image you already have to produce a multi-stage build that can do a full YAML -> PDF conversion.

If you don't like this:
- Let me know if there's something specific I can make better. 