### PR TITLE
Update PyYAML to 4.2b2

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,5 +9,5 @@ coverage==4.5.1
 Sphinx==1.7.5
 pygments==2.2.0
 cryptography==2.2.2
-PyYAML==4.1
+PyYAML==4.2b2
 pytest==3.6.2


### PR DESCRIPTION
4.1 inexplicably seems to have disappeared from pypi.